### PR TITLE
bugfix : remove duplicate audiomanager

### DIFF
--- a/Assets/Scenes/BubbleCoffee_GameScreen.unity
+++ b/Assets/Scenes/BubbleCoffee_GameScreen.unity
@@ -348,56 +348,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 13656657}
   m_CullTransparentMesh: 1
---- !u!1 &24062613
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 24062615}
-  - component: {fileID: 24062614}
-  m_Layer: 0
-  m_Name: Audio_Manager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &24062614
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24062613}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9924ea0ae1130ca448d2dd8c35fb16f7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _musicSource: {fileID: 1046620975}
-  _sfxSource: {fileID: 393412743}
-  _music001: {fileID: 8300000, guid: fe3aa93a794f73346bc95b2db1ed831c, type: 3}
-  _music002: {fileID: 8300000, guid: 35d9b8e4887239d47b42b831ea3e4d50, type: 3}
---- !u!4 &24062615
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24062613}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1235.2902, y: 839.6301, z: -3.0966845}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1046620976}
-  - {fileID: 393412744}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &29303940
 GameObject:
   m_ObjectHideFlags: 0
@@ -3168,7 +3118,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 0
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -3510,134 +3459,6 @@ MonoBehaviour:
   _buttonImage: {fileID: 2049182574}
   _spriteBlank: {fileID: 21300000, guid: 22dbfd4ac3b149d40b75f197748e1fa2, type: 3}
   _spriteCross: {fileID: 21300000, guid: 9747394fe8f267641a2808fa9fa8d462, type: 3}
---- !u!1 &393412742
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 393412744}
-  - component: {fileID: 393412743}
-  m_Layer: 0
-  m_Name: SFX
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!82 &393412743
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393412742}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: -4520863977430128184, guid: 9da64c865f9b59d4e9296a2ae74378cb, type: 2}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 0.5
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!4 &393412744
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393412742}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 24062615}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &393429328
 GameObject:
   m_ObjectHideFlags: 0
@@ -3693,7 +3514,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 0
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -10287,7 +10107,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 1
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -11311,134 +11130,6 @@ MonoBehaviour:
   _minGold: 12
   _maxGold: 18
   objectIsASet: 0
---- !u!1 &1046620974
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1046620976}
-  - component: {fileID: 1046620975}
-  m_Layer: 0
-  m_Name: Music
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!82 &1046620975
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1046620974}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: -6133236849209408909, guid: 9da64c865f9b59d4e9296a2ae74378cb, type: 2}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 0.5
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!4 &1046620976
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1046620974}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 24062615}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1055575513
 GameObject:
   m_ObjectHideFlags: 0
@@ -13202,7 +12893,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 0
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -14343,7 +14033,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 1
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 185776392}
@@ -15079,7 +14768,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 0
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -19560,7 +19248,6 @@ MonoBehaviour:
   ResourceMoney: 0
   CanUseWorker: 0
   WorkerIsClicking: 0
-  WorkerResourceActivated: 0
   _checkmark: {fileID: 21300000, guid: 985174a8b592ef1448f3551d4d37912d, type: 3}
   _cross: {fileID: 21300000, guid: 1471a87af63b9654bb5cea28006f1144, type: 3}
   _imageAutoclickerLogo: {fileID: 219562677}
@@ -19985,4 +19672,3 @@ SceneRoots:
   - {fileID: 928326037}
   - {fileID: 574736953}
   - {fileID: 1999892947}
-  - {fileID: 24062615}


### PR DESCRIPTION
`AudioManager` was initiated in both the Menu scene and the Game scene while being `dontdestroyonload`. This caused two instances to coexist after switching scenes. I removed the `AudioManager` from the Game scene to ensure only one persist.